### PR TITLE
feat(home): port legacy PATH and gitignore entries into Nix config

### DIFF
--- a/home/git.nix
+++ b/home/git.nix
@@ -11,6 +11,7 @@
       ".AppleDouble"
       ".LSOverride"
       ".idea"
+      "**/.claude/settings.local.json"
     ];
 
     # 旧 [filter "lfs"] セクション。enable = true だけで filter 4行を自動生成。

--- a/home/zsh.nix
+++ b/home/zsh.nix
@@ -38,6 +38,7 @@
     "$HOME/Library/Application Support/Herd/bin"
     "$HOME/.volta/bin"
     "$HOME/.cargo/bin"
+    "$HOME/.local/bin"
   ];
 
   # 旧 .fzf.zsh 全部を置き換え。シェル統合と key-bindings/completion を有効化。


### PR DESCRIPTION
## 概要

レガシー側の作業ツリー差分のうち、home-manager 設定に**未反映だった2点**を Nix に取り込みます。これにより Nix が唯一の真実 (source of truth) となり、`zsh/.zshrc` 等のレガシーファイルは安心して破棄でき、Phase 5 での削除もスムーズになります。

## 変更内容

| ファイル | 変更 | 由来 |
|---|---|---|
| `home/zsh.nix` | `home.sessionPath` に `$HOME/.local/bin` を追加 | 旧 `zsh/.zshrc` の `export PATH="$HOME/.local/bin:$PATH"` |
| `home/git.nix` | `ignores` に `**/.claude/settings.local.json` を追加 | 旧 `git/.gitignore_global` の追記分 |

## 照合結果（取り込み不要だったもの）

- Herd PHP 6バージョン → 既に `zsh.nix` の `initContent` に反映済み
- `VOLTA_HOME` → 既に `sessionVariables` に反映済み
- `.cargo/env` の source → `sessionPath` の `$HOME/.cargo/bin` で実質同等

## 備考

- レガシーの `zsh/.zshrc` / `zsh/.zshenv` / `git/.gitignore_global` の作業ツリー差分（machine 固有の絶対パスを含む）は本 PR には含めず、別途破棄します。ファイル自体は方針通り Phase 5 まで残します。
- CI (`installation.yaml` → `sh init.sh` → `brew bundle`) は Homebrew の `homebrew/bundle` tap 廃止により upstream 起因で失敗します。本 PR の内容とは無関係で、Phase 5 で当該ワークフローごと撤去予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)