### PR TITLE
feat(phase3): integrate Brewfile into nix-darwin (CLI→nixpkgs, GUI→casks)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,8 +53,13 @@
           home = "/Users/koyoisono";
         };
 
+        # nix-darwin は system activation を root で実行する方式へ移行した。
+        # homebrew.* など「実行ユーザーに紐づく」オプションは、root ではなく
+        # この primaryUser に適用される。homebrew.enable を使うには宣言必須。
+        system.primaryUser = "koyoisono";
+
         # システムにインストールされるパッケージ。動作確認用に vim を1つだけ。
-        # Phase 3 で CLI ツール群をここに移行する。
+        # ユーザー領域の CLI ツールは home/packages.nix (home.packages) 側で管理する。
         environment.systemPackages = [ pkgs.vim ];
 
         # darwin-version コマンドが返す revision に git commit hash を埋め込む。
@@ -77,6 +82,7 @@
           determinate.darwinModules.default
           home-manager.darwinModules.home-manager
           configuration
+          ./modules/homebrew.nix
           {
             # useGlobalPkgs: home-manager に独自の nixpkgs を持たせず、
             # nix-darwin と同じ nixpkgs を共有。ストア肥大化を防ぐ。

--- a/home/default.nix
+++ b/home/default.nix
@@ -5,6 +5,7 @@
     ./zsh.nix
     ./git.nix
     ./vim.nix
+    ./packages.nix
   ];
 
   # ユーザー識別。/Users/koyoisono が home-manager の管理対象。

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }: {
+  # 旧 Brewfile の CLI formula を nixpkgs に移行 (Phase 3)。
+  # home.packages は home-manager がユーザープロファイル (~/.nix-profile) に入れる。
+  # GUI cask は system レベルの modules/homebrew.nix 側で管理する。
+  #
+  # 移行の対応関係:
+  #   brew "gcc"                    → pkgs.gcc      (GNU Compiler Collection)
+  #   brew "webp"                   → pkgs.libwebp  (cwebp/dwebp 同梱。formula 名と attr 名が違う点に注意)
+  #   brew "zsh-autosuggestions"    → programs.zsh.autosuggestion.enable    で Phase 2 に吸収済み
+  #   brew "zsh-completions"        → programs.zsh.enableCompletion         で Phase 2 に吸収済み
+  #   brew "zsh-syntax-highlighting"→ programs.zsh.syntaxHighlighting.enable で Phase 2 に吸収済み
+  #   brew "zsh-git-prompt"         → starship に移行済み (nixpkgs から削除されたため)
+  home.packages = with pkgs; [
+    gcc
+    libwebp
+  ];
+}

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -1,0 +1,43 @@
+{ ... }: {
+  # nix-darwin の homebrew モジュール (Phase 3)。
+  # GUI アプリは自動更新・Spotlight 連携の都合で Homebrew cask のまま管理する方針 (CLAUDE.md)。
+  # nix-darwin は Brewfile を生成して `brew bundle` を回すだけで、Homebrew 本体は別途インストール済みが前提。
+  homebrew = {
+    enable = true;
+
+    # onActivation: darwin-rebuild switch 時の brew の挙動。
+    #   cleanup: 生成 Brewfile に無い formula/cask の扱い。値は "none" | "check" | "uninstall" | "zap"。
+    #     - "none"     : 何もしない (既存の手動 brew install を消さない)
+    #     - "uninstall": Brewfile に無いものをアンインストール
+    #     - "zap"      : uninstall + 設定ファイルまで完全削除
+    #   移行期は破壊的でない "none" にしておき、Brewfile への列挙が出揃ってから "zap" へ上げる。
+    #   autoUpdate / upgrade も activation のたびに走ると遅く・非決定的なので false。
+    onActivation = {
+      cleanup = "none";
+      autoUpdate = false;
+      upgrade = false;
+    };
+
+    # 旧 Brewfile の cask 群。token はそのまま流用。
+    # 旧 tap "homebrew/bundle" / "homebrew/services" は upstream 廃止 + nix-darwin が
+    # Brewfile を自前生成するため不要。意図的に持ち込まない。
+    casks = [
+      "discord"
+      # 旧 Brewfile は "docker" だったが、現在の Homebrew では正式 token が
+      # "docker-desktop" にリネームされている (旧名は deprecated エイリアス)。
+      "docker-desktop"
+      "herd"
+      "google-chrome"
+      "logi-options+"
+      "notion"
+      "phpstorm"
+      "iterm2"
+      "zoom"
+      "tableplus"
+      "postman"
+      "slack"
+      "chatwork"
+      "visual-studio-code"
+    ];
+  };
+}


### PR DESCRIPTION
## 概要

Phase 3。旧 `Brewfile` を nix-darwin / home-manager に統合します。CLI ツールは nixpkgs、GUI アプリは `homebrew.casks` 経由で brew に残す、という CLAUDE.md の方針通りの構成です。

## 変更内容

### `home/packages.nix`（新規）— CLI formula → nixpkgs
| 旧 Brewfile | 移行先 |
|---|---|
| `brew "gcc"` | `pkgs.gcc` |
| `brew "webp"` | `pkgs.libwebp`（`cwebp`/`dwebp` 同梱。formula 名と attr 名が異なる） |
| `brew "zsh-autosuggestions"` | Phase 2 で `programs.zsh.autosuggestion.enable` に吸収済み |
| `brew "zsh-completions"` | Phase 2 で `programs.zsh.enableCompletion` に吸収済み |
| `brew "zsh-syntax-highlighting"` | Phase 2 で `programs.zsh.syntaxHighlighting.enable` に吸収済み |
| `brew "zsh-git-prompt"` | starship に移行済み（nixpkgs から削除） |

### `modules/homebrew.nix`（新規）— GUI cask → nix-darwin
- 14 個の cask を `homebrew.casks` で宣言（自動更新・Spotlight 連携の都合で brew のまま）
- `onActivation.cleanup = "none"`（移行期は非破壊。列挙が出揃ったら `"zap"` へ上げる）
- `"docker"` → `"docker-desktop"`（現行 Homebrew でリネームされた正式 token に修正）
- 旧 `tap "homebrew/bundle"` / `"homebrew/services"` は nix-darwin が Brewfile を自前生成するため持ち込まない

### `flake.nix`
- `modules` に `./modules/homebrew.nix` を追加
- `system.primaryUser = "koyoisono"` を宣言（nix-darwin が activation を root 実行へ移行したため、`homebrew.*` 等は primaryUser に適用される）

### `home/default.nix`
- `imports` に `./packages.nix` を追加

## 動作確認

`sudo darwin-rebuild switch --flake .#mymac` で以下を確認済み：
- `brew bundle complete! 14 Brewfile dependencies now installed.`（緑）
- home-manager activation 完走
- `gcc` / `libwebp` がユーザープロファイルに導入

## 備考

- レガシースクリプト（`init.sh` / `brew.sh` / `Brewfile`）と CI (`installation.yaml`) は方針通り Phase 5 まで残します。CI が赤いのは旧 `brew bundle` の upstream tap 廃止が原因で、本 PR とは無関係です。
- 旧 brew 版の `gcc`/`webp`/zsh プラグインは `cleanup="none"` のため残存します（重複するが無害。Phase 5 で `brew uninstall` 整理予定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)