### PR TITLE
feat(phase4): declare macOS system settings via system.defaults

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
           home-manager.darwinModules.home-manager
           configuration
           ./modules/homebrew.nix
+          ./system/defaults.nix
           {
             # useGlobalPkgs: home-manager に独自の nixpkgs を持たせず、
             # nix-darwin と同じ nixpkgs を共有。ストア肥大化を防ぐ。

--- a/home/default.nix
+++ b/home/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }: {
+{ pkgs, lib, ... }: {
   # imports: 機能ごとに分割した子モジュールを取り込む。
   # 子モジュールも (pkgs, ...) を受け取り、option を merge していく。
   imports = [
@@ -19,4 +19,12 @@
   # home-manager 自身を home-manager で管理する宣言 (再帰的)。
   # これで `home-manager` コマンドが PATH に入る。
   programs.home-manager.enable = true;
+
+  # スクリーンショット保存先フォルダを用意する (system/defaults.nix の
+  # screencapture.location と対。root ではなくユーザー権限で作るため home-manager 側)。
+  # lib.hm.dag.entryAfter ["writeBoundary"] = dotfile のリンク確定後に実行する activation。
+  home.activation.createScreenshotsDir =
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      run mkdir -p "$HOME/Screenshots"
+    '';
 }

--- a/system/defaults.nix
+++ b/system/defaults.nix
@@ -1,0 +1,63 @@
+{ ... }: {
+  # Phase 4: macOS システム設定の宣言化。
+  # system.defaults.<domain>.<key> は switch 時に root 権限で `defaults write` を実行し、
+  # Dock / Finder を再起動して即反映する。手動 GUI 設定はここで上書きされる点に注意。
+  # オプション名・型は nix-darwin の pin 済みソース (rev 56c666e) で確認済み。
+  # 全オプションは nullOr 型 = 未設定(null)なら macOS デフォルトのまま触らない。
+  system.defaults = {
+
+    # ── Dock ─────────────────────────────────────────────
+    dock = {
+      autohide = true; # Dock を自動的に隠す
+      autohide-delay = 0.0; # ホバーから表示までの遅延 (秒)。0 で即表示
+      show-recents = false; # 「最近使ったアプリ」を Dock に出さない
+      mru-spaces = false; # スペースを最近の使用順に並べ替えない (デスクトップ配置が固定される)
+      tilesize = 48; # アイコンサイズ (px)
+      magnification = false; # ホバー時の拡大を無効
+      minimize-to-application = true; # 最小化したウィンドウをアプリアイコンに格納
+      show-process-indicators = true; # 起動中アプリのインジケータ点を表示
+      orientation = "bottom"; # Dock の位置: "bottom" | "left" | "right"
+
+      # ホットコーナー (任意): wvous-{tl,tr,bl,br}-corner に整数コードを入れる。
+      # 1=無効 2=Mission Control 4=デスクトップ表示 5=スクリーンセーバ開始
+      # 11=Launchpad 13=画面ロック 14=クイックメモ
+      # 例) 右下を画面ロックにする場合:
+      # wvous-br-corner = 13;
+    };
+
+    # ── Finder ───────────────────────────────────────────
+    finder = {
+      AppleShowAllExtensions = true; # 拡張子を常に表示
+      ShowPathbar = true; # 下部にパスバーを表示
+      ShowStatusBar = true; # 下部にステータスバーを表示
+      _FXShowPosixPathInTitle = true; # タイトルバーにフルパスを表示
+      FXPreferredViewStyle = "Nlsv"; # 既定の表示: "Nlsv"=リスト "icnv"=アイコン "clmv"=カラム "Flwv"=ギャラリー
+      FXEnableExtensionChangeWarning = false; # 拡張子変更時の警告を出さない
+      _FXSortFoldersFirst = true; # フォルダを先頭にまとめてソート
+      AppleShowAllFiles = false; # 隠しファイルは非表示 (true で表示)
+    };
+
+    # ── キーボード / 入力 (NSGlobalDomain) ────────────────
+    NSGlobalDomain = {
+      InitialKeyRepeat = 15; # キー長押しからリピート開始までの時間 (小さいほど速い)
+      KeyRepeat = 2; # リピート間隔 (小さいほど速い)
+      ApplePressAndHoldEnabled = false; # 長押しでアクセント候補ではなくキーリピートさせる (vim 向き)
+      NSAutomaticCapitalizationEnabled = false; # 自動大文字化オフ
+      NSAutomaticDashSubstitutionEnabled = false; # ダッシュの自動置換オフ
+      NSAutomaticQuoteSubstitutionEnabled = false; # スマートクオート置換オフ
+      NSAutomaticPeriodSubstitutionEnabled = false; # ピリオドの自動挿入オフ
+      NSAutomaticSpellingCorrectionEnabled = false; # 自動スペル修正オフ
+      AppleShowAllExtensions = true; # 拡張子表示 (finder と揃える)
+    };
+
+    # ── スクリーンショット ───────────────────────────────
+    screencapture = {
+      # 保存先。screencapture は "~" を展開しないので絶対パスで指定する。
+      # フォルダ自体は home-manager 側 (home/default.nix) で作成する。
+      location = "/Users/koyoisono/Screenshots";
+      type = "png"; # 保存形式
+      disable-shadow = true; # ウィンドウ撮影時の影を付けない
+      show-thumbnail = true; # 撮影後にサムネイルを表示
+    };
+  };
+}


### PR DESCRIPTION
## 概要

Phase 4。macOS のシステム設定を `system.defaults.*` で宣言化します。`switch` 時に root 権限で `defaults write` が走り、Dock / Finder を再起動して即反映されます。

オプション名・型・許容値は flake.lock で pin した nix-darwin (rev `56c666e`) のソースで確認済みです（憶測なし）。全オプションは `nullOr` 型 = 未設定なら macOS デフォルトを触りません。

## 変更内容

### `system/defaults.nix`（新規）
| ドメイン | 主な設定 |
|---|---|
| **dock** | `autohide`, `show-recents=false`, `mru-spaces=false`, `tilesize=48`, `magnification=false`, `minimize-to-application`, `orientation="bottom"` |
| **finder** | `AppleShowAllExtensions`, `ShowPathbar`, `ShowStatusBar`, `_FXShowPosixPathInTitle`, `FXPreferredViewStyle="Nlsv"`, `_FXSortFoldersFirst` |
| **NSGlobalDomain** | `InitialKeyRepeat=15`, `KeyRepeat=2`, `ApplePressAndHoldEnabled=false`, 自動大文字化/スマートクオート/スペル修正オフ |
| **screencapture** | `location=~/Screenshots`(絶対パス), `type="png"`, `disable-shadow`, `show-thumbnail` |

ホットコーナーはコメントで例示のみ（コード表付き）。

### `home/default.nix`
- `screencapture.location` 用に `~/Screenshots` を home-manager の activation（`lib.hm.dag.entryAfter ["writeBoundary"]`）で作成。root 実行の system 側ではなくユーザー権限で作るため home-manager に置いた。`lib` を引数に追加。

### `flake.nix`
- `modules` に `./system/defaults.nix` を追加。

## 動作確認

`sudo darwin-rebuild switch --flake .#mymac` で確認済み：
- Dock / Finder が再起動し各設定が即反映
- `~/Screenshots` フォルダが自動作成され、スクショ保存先が切り替わる

## 備考

- `screencapture.location` は `~` を展開しないため絶対パス指定。本リポジトリは既に `users.users.koyoisono` 等でユーザー名をハードコードしているため整合的。
- レガシースクリプト・`Brewfile`・CI (`installation.yaml`) は方針通り Phase 5 まで残します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)