### PR TITLE
docs: clarify initial Nix handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,35 @@ git clone https://github.com/wadakatu/dotfiles.git ~/www/dotfiles
 cd ~/www/dotfiles
 
 # 評価とビルド。ユーザー環境にはまだ適用しない
-nix flake check --show-trace
-nix build .#darwinConfigurations.mymac.system --no-link --show-trace
+nix flake check --no-update-lock-file path:. --show-trace
+nix build path:.#darwinConfigurations.mymac.system --no-link --show-trace
+```
 
-# 初回だけ nix run で darwin-rebuild を起動する
-sudo nix run nix-darwin/master#darwin-rebuild -- \
+Determinate NixのmacOSパッケージは、インストール時に
+`/etc/nix/nix.custom.conf`を通常ファイルとして作成する。一方、この構成は
+`determinateNix.customSettings`で同じファイルをnix-darwinの管理対象にするため、
+初回activationの前に既存設定を確認して管理を引き継ぐ。
+
+次のコマンドはコメントと空行を除いた設定キーだけを表示し、値は表示しない。
+
+```bash
+sudo awk -F= '/^[[:space:]]*($|#)/{next}{key=$1;gsub(/^[[:space:]]+|[[:space:]]+$/,"",key);print key}' /etc/nix/nix.custom.conf
+```
+
+何も表示されなければ、既存ファイルを削除せずバックアップ名へ退避する。
+
+```bash
+sudo mv /etc/nix/nix.custom.conf /etc/nix/nix.custom.conf.before-nix-darwin
+```
+
+設定キーが表示された場合は退避前に止まり、必要な設定を
+`determinateNix.customSettings`へ移植する。トークン等の値はGitへコミットしない。
+
+初回だけ`nix run`で`darwin-rebuild`を起動する。`sudo -H`でrootの`HOME`を
+`/var/root`にし、ユーザーHOMEの所有権警告を避ける。
+
+```bash
+sudo -H /nix/var/nix/profiles/default/bin/nix run nix-darwin/master#darwin-rebuild -- \
   switch --flake .#mymac
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,9 @@
         # Determinate にインストールされた Nix を使う宣言。
         # これを true にすることで nix-darwin 側の nix.* 系オプションは無効化される。
         # customSettings = {} は /etc/nix/nix.custom.conf (Determinate が作成するファイル) の
-        # 所有権を nix-darwin に渡す宣言。これを書かないと "Unexpected files in /etc" で
-        # activation が中断する (https://github.com/LnL7/nix-darwin/issues/1298)。
+        # 所有権を nix-darwin に渡す宣言。Determinate導入直後の通常ファイルは初回activation前に
+        # 内容を確認して .before-nix-darwin へ退避する (README参照)。この宣言がない場合も
+        # "Unexpected files in /etc" でactivationが中断する。
         determinateNix = {
           enable = true;
           customSettings = { };


### PR DESCRIPTION
## 変更内容

- 新しいMacでDeterminate Nixからnix-darwinへ`/etc/nix/nix.custom.conf`の管理を引き継ぐ手順を追加
- 設定値を表示せずキーだけ確認し、空の場合だけバックアップ名へ退避する方針を明記
- 初回`darwin-rebuild`を`sudo -H`と絶対パスで実行し、root実行時のHOME所有権警告を回避
- 初回のflake確認コマンドを、移行時に検証済みの`path:.`と`--no-update-lock-file`へ統一

## 背景

Determinate NixのmacOSパッケージが通常ファイルとして作成する`/etc/nix/nix.custom.conf`と、`determinateNix.customSettings`で同ファイルを管理するnix-darwinが初回activation時に衝突し、安全チェックで停止していました。

## 影響

新しいMacの初回セットアップで、既存設定を誤って上書きせずに管理を引き継げるようになります。Nix設定の実体には変更ありません。

## 確認

- `git diff --check`: 成功
- `nix flake check`: CodexサンドボックスからNix daemonへの接続が拒否されたためローカルでは未実行。GitHub ActionsのmacOSチェックをマージ条件とします。
