### PR TITLE
feat(agents): version-control Claude Code global settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Nix由来のパッケージと設定は `flake.lock` で固定する。Homebrew 
 | CLI パッケージ | nixpkgs `home.packages` |
 | GUI アプリ | nix-darwin `homebrew.casks` |
 | Dock / Finder / キーボード / スクリーンショット | nix-darwin `system.defaults` |
-| Claude Code / Codex のスキル・コマンド | `agents/` に実体を置き手動コピー（Nix 管理外） |
+| Claude Code / Codex の設定・スキル・コマンド | `agents/` に実体を置き手動コピー（Nix 管理外） |
 | シークレット、アプリデータ、ブラウザデータ | Keychain / 1Password / バックアップ |
 
 ## 構成
@@ -30,6 +30,9 @@ Nix由来のパッケージと設定は `flake.lock` で固定する。Homebrew 
 ├── flake.lock
 ├── agents/
 │   ├── claude/
+│   │   ├── settings.json # 権限・フック・ステータスライン
+│   │   ├── CLAUDE.md     # グローバル指示
+│   │   ├── statusline.py # 2行ステータスライン
 │   │   ├── commands/     # /commit /pr /review-pr-comments /next /fix-ci
 │   │   │                 # /sync-pr /verify-no-regression /close-issue
 │   │   ├── skills/       # defer-to-issue, research, memory-triage
@@ -136,41 +139,41 @@ darwin-rebuild build --flake .#mymac
 
 ## エージェントスキルとコマンド
 
-Claude Code と Codex の自作スキル・コマンドは `agents/` に実体を置く。Nix 管理では
+Claude Code と Codex の設定・自作スキル・コマンドは `agents/` に実体を置く。Nix 管理では
 なくリポジトリを正とし、home 側へ手動コピーして反映する（Claude に依頼してもよい）。
+
+Claude Code の設定を Nix の `home.file` でシンボリックリンクにしないのは、`~/.claude`
+配下が読み取り専用になると Claude Code 自身（`/config`、権限ダイアログの「常に許可」、
+プラグイン導入）が設定を書き換えられなくなるため。
 
 | リポジトリ | 配置先 |
 |---|---|
+| `agents/claude/settings.json` | `~/.claude/settings.json` |
+| `agents/claude/CLAUDE.md` | `~/.claude/CLAUDE.md` |
+| `agents/claude/statusline.py` | `~/.claude/statusline.py` |
 | `agents/claude/skills/` | `~/.claude/skills/` |
 | `agents/claude/commands/` | `~/.claude/commands/` |
 | `agents/claude/hooks/` | `~/.claude/hooks/` |
 | `agents/codex/skills/` | `~/.codex/skills/` |
 
 ```bash
+mkdir -p ~/.claude/skills ~/.claude/commands ~/.claude/hooks ~/.codex/skills
+cp -f agents/claude/settings.json agents/claude/CLAUDE.md agents/claude/statusline.py ~/.claude/
+chmod +x ~/.claude/statusline.py
 cp -R agents/claude/skills/* ~/.claude/skills/
 cp agents/claude/commands/*.md ~/.claude/commands/
 cp agents/claude/hooks/*.sh ~/.claude/hooks/
+chmod +x ~/.claude/hooks/*.sh
 cp -R agents/codex/skills/* ~/.codex/skills/
 ```
 
+`settings.json` にはステータスライン、権限ルール、フック登録がまとまっている。
 `branch-guard.sh`（保護ブランチ main / master / dev 上での `git commit` / `git push` と、
-保護ブランチを push 先に指名するコマンドをブロックする PreToolUse フック）は、
-コピーに加えて `~/.claude/settings.json` への登録が必要。
+保護ブランチを push 先に指名するコマンドをブロックする PreToolUse フック）も
+登録済みなので、コピー以外の手作業は不要。
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          { "type": "command", "command": "/Users/wadakatu/.claude/hooks/branch-guard.sh" }
-        ]
-      }
-    ]
-  }
-}
-```
+`~/.claude/settings.local.json` は Claude Code が権限の「常に許可」を書き込む
+ローカル専用ファイル。リポジトリには取り込まない。
 
 home 側で直接編集した場合は同じ対応でリポジトリへ取り込み直す。ここにないスキル
 （herdr、hatch-pet など外部配布物や実験中のもの）はローカル管理のままとする。

--- a/agents/claude/CLAUDE.md
+++ b/agents/claude/CLAUDE.md
@@ -1,0 +1,35 @@
+# グローバル指示
+
+全プロジェクト共通。プロジェクト固有のことは各リポジトリの CLAUDE.md に書く。
+
+## 応答
+
+- 日本語で回答する。コード・コミットメッセージ・識別子は英語のまま。
+- 不確かな API・オプション名・仕様は憶測で書かず、公式ドキュメントを引いてから答える。
+  参照したら URL を示す。
+
+## この Mac の環境
+
+- **nix-darwin + home-manager 管理**。`~/.zshrc` `~/.config/git/config`
+  `~/.config/ghostty/config` などは `/nix/store` への読み取り専用シンボリックリンク。
+  **直接編集しない**。実体は `~/www/dotfiles` にあり、そこを直してから反映する。
+- 反映コマンドは副作用が大きいので、自分で実行せずプロンプトに提示してユーザーに実行してもらう:
+  `! cd ~/www/dotfiles && sudo darwin-rebuild switch --flake .#mymac`
+- ランタイムは **mise**（node / bun / pnpm / yarn / python）。PHP は **Herd**（8.2〜8.5）。
+- 使えるツール: `gh` `rg` `jq` `yq` `glow` `age` `uv` `imagemagick` `gcloud`
+- `mise exec` / `npx` / `docker exec` のようなランナー経由の実行は権限ルールをすり抜けるので、
+  中身のコマンドを直接書く。
+
+## Claude Code 自身の設定
+
+`~/.claude/{settings.json,CLAUDE.md,statusline.py,commands,skills,hooks}` は
+**`~/www/dotfiles/agents/claude/` が正**。`~/.claude` 側は手動コピーされた複製。
+
+`~/.claude` を直接編集したら、同じ内容を dotfiles 側にも反映してコミットすること
+（逆方向のコピーは `~/www/dotfiles/README.md` の手順を参照）。
+
+## 作業のしかた
+
+- 破壊的・不可逆な操作（force push を除く履歴書き換え、リソース削除、外部への送信）は
+  実行前に確認する。
+- テストが落ちたら落ちたと報告する。通っていない状態を「完了」と言わない。

--- a/agents/claude/settings.json
+++ b/agents/claude/settings.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "chrome-devtools-mcp@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true,
+    "laravel-boost@claude-plugins-official": true,
+    "context7@claude-plugins-official": true
+  },
+
+  "tui": "fullscreen",
+  "theme": "dark",
+  "agentPushNotifEnabled": true,
+
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.py",
+    "refreshInterval": 10,
+    "padding": 0
+  },
+
+  "cleanupPeriodDays": 90,
+  "askUserQuestionTimeout": "10m",
+
+  "permissions": {
+    "deny": [
+      "Read(//**/.env)",
+      "Read(//**/.env.local)",
+      "Read(//**/.env.production)",
+      "Read(//**/.env.staging)",
+      "Read(//**/.env.testing)",
+      "Read(//**/*.pem)",
+      "Read(//**/*.p12)",
+      "Read(//**/id_rsa)",
+      "Read(//**/id_ed25519)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.gnupg/**)",
+      "Read(~/.config/gh/**)",
+      "Read(~/.claude/.credentials.json)",
+
+      "Edit(//nix/store/**)",
+
+      "Bash(sudo *)",
+      "Bash(rm -rf /)",
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf ~)",
+      "Bash(rm -rf ~/*)",
+      "Bash(chmod 777 *)"
+    ],
+
+    "ask": [
+      "Bash(git config --global *)",
+      "Bash(darwin-rebuild *)",
+      "Bash(home-manager *)",
+      "Bash(nix run nix-darwin *)",
+      "Bash(nix-collect-garbage *)",
+      "Bash(brew *)"
+    ],
+
+    "allow": [
+      "Bash(git status *)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git show *)",
+      "Bash(git branch *)",
+      "Bash(git remote *)",
+      "Bash(git blame *)",
+      "Bash(git rev-parse *)",
+      "Bash(git ls-files *)",
+      "Bash(git stash list *)",
+      "Bash(git worktree list *)",
+      "Bash(git shortlog *)",
+      "Bash(git describe *)",
+
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh issue view *)",
+      "Bash(gh issue list *)",
+      "Bash(gh run list *)",
+      "Bash(gh run view *)",
+      "Bash(gh repo view *)",
+      "Bash(gh release list *)",
+
+      "Bash(rg *)",
+      "Bash(ls *)",
+      "Bash(tree *)",
+      "Bash(jq *)",
+      "Bash(yq *)",
+      "Bash(glow *)",
+      "Bash(* --version)",
+      "Bash(* --help *)",
+
+      "Bash(mise ls *)",
+      "Bash(mise current *)",
+      "Bash(nix flake metadata *)",
+      "Bash(nix flake show *)",
+      "Bash(nix flake check *)",
+      "Bash(nix fmt *)",
+
+      "Bash(composer show *)",
+      "Bash(composer validate *)",
+      "Bash(php artisan test *)",
+      "Bash(php artisan route:list *)",
+      "Bash(php artisan about *)",
+      "Bash(vendor/bin/pest *)",
+      "Bash(vendor/bin/phpunit *)",
+      "Bash(vendor/bin/pint *)",
+      "Bash(vendor/bin/phpstan *)",
+
+      "Bash(pnpm test *)",
+      "Bash(pnpm lint *)",
+      "Bash(pnpm run test *)",
+      "Bash(pnpm run lint *)",
+      "Bash(pnpm run typecheck *)",
+      "Bash(pnpm run format *)",
+      "Bash(npm test *)",
+      "Bash(npm run test *)",
+      "Bash(npm run lint *)",
+      "Bash(npm run typecheck *)",
+      "Bash(bun test *)",
+      "Bash(bun run test *)",
+      "Bash(bun run lint *)",
+
+      "WebFetch(domain:code.claude.com)",
+      "WebFetch(domain:docs.claude.com)",
+      "WebFetch(domain:platform.claude.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:nix.dev)",
+      "WebFetch(domain:nixos.org)",
+      "WebFetch(domain:search.nixos.org)",
+      "WebFetch(domain:nix-community.github.io)",
+      "WebFetch(domain:nix-darwin.github.io)",
+      "WebFetch(domain:laravel.com)",
+      "WebFetch(domain:php.net)",
+      "WebFetch(domain:developer.mozilla.org)"
+    ]
+  },
+
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/branch-guard.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/afplay",
+            "args": ["/System/Library/Sounds/Glass.aiff"],
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt|agent_needs_input",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/afplay",
+            "args": ["/System/Library/Sounds/Ping.aiff"],
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/agents/claude/statusline.py
+++ b/agents/claude/statusline.py
@@ -1,0 +1,296 @@
+#!/usr/bin/python3
+"""Claude Code のステータスライン (2行表示)。
+
+stdin にセッション情報の JSON が渡され、stdout に出したものがそのまま
+画面下部に表示される。1 echo = 1行。
+
+実装方針:
+- 外部依存なし。shebang を `env python3` ではなく macOS 標準の `/usr/bin/python3`
+  に固定してあるのは、statusLine が起動するシェルで PATH（nix profile / mise shim）
+  が揃っている保証がないため。同じ理由で jq も使わない。
+  単一プロセスで済むので bash + jq より起動も速い。
+- git はリポジトリが大きいと遅いので session_id ごとに5秒キャッシュする。
+  プロセス ID をキーにするとキャッシュが毎回ミスするので使わない。
+- 端末幅は tput cols では取れない (Claude Code が stdout を横取りするため)。
+  Claude Code が渡してくる COLUMNS 環境変数を読む。
+- 何があっても例外で落とさない。落ちるとステータスラインが空になる。
+
+表示:
+  ◆ Opus 5 high · ~/www/dotfiles · main ↑2 +2 ~5 ?1
+  ███████░░░ 68% · $1.24 · 12m · +156/-23
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+# --- ANSI カラー -----------------------------------------------------------
+# Nerd Font は入っていない (JetBrains Mono) ので、グリフは Unicode の
+# ブロック要素・矢印など素の等幅フォントに含まれるものだけを使う。
+RESET = "\033[0m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+BLUE = "\033[34m"
+MAGENTA = "\033[35m"
+CYAN = "\033[36m"
+GRAY = "\033[90m"
+
+SEP = f"{GRAY} · {RESET}"
+BAR_WIDTH = 10
+GIT_CACHE_TTL = 5.0
+GIT_TIMEOUT = 2.0
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m|\033\][^\a]*\a")
+
+
+def paint(text: str, *codes: str) -> str:
+    return f"{''.join(codes)}{text}{RESET}" if codes else text
+
+
+def vis_len(text: str) -> int:
+    """ANSI エスケープを除いた表示上の文字数。"""
+    return len(_ANSI_RE.sub("", text))
+
+
+# --- git -------------------------------------------------------------------
+def _git_status(cwd: str) -> dict:
+    """porcelain=v2 --branch を1回だけ叩いて、必要な情報をまとめて取る。
+
+    ブランチ名・ahead/behind・staged/modified/untracked/conflict が
+    この1コマンドで揃うので、git を複数回呼ぶより速い。
+    """
+    result = subprocess.run(
+        ["git", "status", "--porcelain=v2", "--branch", "--untracked-files=normal"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=GIT_TIMEOUT,
+    )
+    if result.returncode != 0:
+        return {}
+
+    info = {
+        "branch": "",
+        "ahead": 0,
+        "behind": 0,
+        "staged": 0,
+        "modified": 0,
+        "untracked": 0,
+        "conflict": 0,
+    }
+    for line in result.stdout.splitlines():
+        if line.startswith("# branch.head "):
+            head = line[len("# branch.head "):]
+            info["branch"] = head
+        elif line.startswith("# branch.oid ") and not info["branch"]:
+            info["branch"] = line[len("# branch.oid "):][:7]
+        elif line.startswith("# branch.ab "):
+            for token in line[len("# branch.ab "):].split():
+                if token.startswith("+"):
+                    info["ahead"] = int(token[1:])
+                elif token.startswith("-"):
+                    info["behind"] = int(token[1:])
+        elif line.startswith("? "):
+            info["untracked"] += 1
+        elif line.startswith("u "):
+            info["conflict"] += 1
+        elif line[:2] in ("1 ", "2 "):
+            # "1 XY ..." の XY が index/worktree の状態。'.' は変更なし。
+            xy = line[2:4]
+            if xy[0] != ".":
+                info["staged"] += 1
+            if xy[1] != ".":
+                info["modified"] += 1
+
+    if info["branch"] == "(detached)":
+        info["branch"] = "detached"
+    return info
+
+
+def git_info(cwd: str, session_id: str) -> dict:
+    """git 情報を5秒キャッシュ付きで取得する。"""
+    key = hashlib.md5(f"{session_id}:{cwd}".encode()).hexdigest()[:16]
+    cache_path = os.path.join(tempfile.gettempdir(), f"cc-statusline-{key}.json")
+
+    try:
+        if time.time() - os.path.getmtime(cache_path) < GIT_CACHE_TTL:
+            with open(cache_path) as f:
+                return json.load(f)
+    except (OSError, ValueError):
+        pass
+
+    try:
+        info = _git_status(cwd)
+    except (OSError, subprocess.SubprocessError):
+        info = {}
+
+    try:
+        # 一時ファイル経由で置換し、並行セッションが壊れた JSON を読まないようにする。
+        tmp_path = f"{cache_path}.{os.getpid()}"
+        with open(tmp_path, "w") as f:
+            json.dump(info, f)
+        os.replace(tmp_path, cache_path)
+    except OSError:
+        pass
+
+    return info
+
+
+# --- 整形 ------------------------------------------------------------------
+def fmt_dir(cwd: str, project_dir: str) -> str:
+    """ホーム相対のパス。cwd が project_dir から外れていれば cwd を出す。"""
+    home = os.path.expanduser("~")
+    base = cwd or project_dir or home
+
+    if project_dir and cwd and cwd != project_dir:
+        rel = os.path.relpath(cwd, project_dir)
+        if not rel.startswith(".."):
+            base = os.path.join(project_dir, rel)
+
+    if base.startswith(home):
+        base = "~" + base[len(home):]
+    return base
+
+
+def fmt_duration(ms: float) -> str:
+    total = int(ms // 1000)
+    if total < 60:
+        return f"{total}s"
+    minutes, _ = divmod(total, 60)
+    if minutes < 60:
+        return f"{minutes}m"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m"
+
+
+def pct_color(pct: float, warn: float, danger: float) -> str:
+    if pct >= danger:
+        return RED
+    if pct >= warn:
+        return YELLOW
+    return GREEN
+
+
+def context_bar(pct: float) -> str:
+    filled = max(0, min(BAR_WIDTH, int(round(pct / (100 / BAR_WIDTH)))))
+    bar = "█" * filled + "░" * (BAR_WIDTH - filled)
+    color = pct_color(pct, 70, 90)
+    return f"{paint(bar, color)} {paint(f'{pct:.0f}%', color)}"
+
+
+def fit(segments: list[tuple[str, bool]], width: int) -> str:
+    """幅に収まるまで、末尾から optional なセグメントを落としていく。
+
+    segments は (表示文字列, 必須か) のリスト。
+    """
+    while True:
+        line = SEP.join(text for text, _ in segments)
+        if vis_len(line) <= width or all(required for _, required in segments):
+            return line
+        for i in range(len(segments) - 1, -1, -1):
+            if not segments[i][1]:
+                del segments[i]
+                break
+
+
+def build(data: dict, width: int) -> list[str]:
+    model = data.get("model") or {}
+    workspace = data.get("workspace") or {}
+    cost = data.get("cost") or {}
+    ctx = data.get("context_window") or {}
+
+    cwd = workspace.get("current_dir") or data.get("cwd") or os.getcwd()
+    project_dir = workspace.get("project_dir") or cwd
+
+    # --- 1行目 ---
+    line1: list[tuple[str, bool]] = []
+
+    model_name = model.get("display_name") or "claude"
+    head = f"{paint('◆', MAGENTA)} {paint(model_name, BOLD, CYAN)}"
+    effort = ((data.get("effort") or {}).get("level") or "").strip()
+    if effort and effort != "medium":
+        head += f" {paint(effort, DIM)}"
+    if data.get("fast_mode"):
+        head += f" {paint('fast', DIM, YELLOW)}"
+    line1.append((head, True))
+
+    line1.append((paint(fmt_dir(cwd, project_dir), BLUE), True))
+
+    git = git_info(cwd, data.get("session_id") or "nosession")
+    if git.get("branch"):
+        parts = [paint(git["branch"], GREEN)]
+        worktree = workspace.get("git_worktree") or (data.get("worktree") or {}).get("name")
+        if worktree:
+            parts.append(paint(f"[wt:{worktree}]", MAGENTA))
+        if git.get("ahead"):
+            parts.append(paint(f"↑{git['ahead']}", CYAN))
+        if git.get("behind"):
+            parts.append(paint(f"↓{git['behind']}", CYAN))
+        if git.get("staged"):
+            parts.append(paint(f"+{git['staged']}", GREEN))
+        if git.get("modified"):
+            parts.append(paint(f"~{git['modified']}", YELLOW))
+        if git.get("untracked"):
+            parts.append(paint(f"?{git['untracked']}", GRAY))
+        if git.get("conflict"):
+            parts.append(paint(f"!{git['conflict']}", RED))
+        line1.append((" ".join(parts), False))
+
+    # --- 2行目 ---
+    line2: list[tuple[str, bool]] = []
+
+    used = ctx.get("used_percentage")
+    if used is None:
+        line2.append((f"{paint('░' * BAR_WIDTH, GRAY)} {paint('--%', GRAY)}", True))
+    else:
+        line2.append((context_bar(float(used)), True))
+
+    total_cost = cost.get("total_cost_usd")
+    if total_cost:
+        line2.append((paint(f"${float(total_cost):.2f}", YELLOW), False))
+
+    duration = cost.get("total_duration_ms")
+    if duration:
+        line2.append((paint(fmt_duration(float(duration)), DIM), False))
+
+    added = int(cost.get("total_lines_added") or 0)
+    removed = int(cost.get("total_lines_removed") or 0)
+    if added or removed:
+        line2.append((f"{paint(f'+{added}', GREEN)}{paint('/', GRAY)}{paint(f'-{removed}', RED)}", False))
+
+    return [fit(line1, width), fit(line2, width)]
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (ValueError, OSError):
+        return
+
+    try:
+        width = int(os.environ.get("COLUMNS") or 120)
+    except ValueError:
+        width = 120
+    width = max(40, width - 2)
+
+    try:
+        for line in build(data, width):
+            print(line)
+    except Exception:
+        # 何かあっても最低限モデル名だけは出す。
+        model = ((data.get("model") or {}).get("display_name")) or "claude"
+        print(f"◆ {model}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# 概要

`~/.claude` 配下のグローバル設定（権限・フック・ステータスライン・グローバル指示）をリポジトリ管理下に移し、新しい Mac でコピーするだけで同じ Claude Code 環境が再現される状態にする。#20 で追加した `branch-guard.sh` の `settings.json` 手動登録も不要になる。

## 変更内容

- `agents/claude/settings.json` を追加
  - `statusLine` 登録（`refreshInterval: 10` でサブエージェント待機中も更新）
  - `permissions.deny` — `.env` 系・`~/.ssh` `~/.aws` `~/.gnupg` `~/.config/gh`・秘密鍵・`sudo`・`rm -rf /` 系。`Edit(//nix/store/**)` はシンボリックリンク解決を利用し、home-manager 生成ファイル（`~/.zshrc` `~/.config/git/config` 等）への書き込みをまとめてブロックする
  - `permissions.ask` — `darwin-rebuild` / `home-manager` / `brew` / `git config --global` / `nix-collect-garbage`
  - `permissions.allow` — 読み取り専用の git・gh・rg・jq 系、テスト/lint ランナー（pest・phpunit・pint・phpstan・artisan test、pnpm/npm/bun の test・lint・typecheck）、公式ドキュメントの WebFetch ドメイン
  - `hooks` — `branch-guard.sh` の `PreToolUse` 登録、`Stop` / `Notification` の完了音（いずれも `async: true`）
- `agents/claude/statusline.py` を追加（2行表示）
  - 1行目: モデル・effort・パス・ブランチ・ahead/behind・staged/modified/untracked/conflict
  - 2行目: コンテキスト使用率バー（70% 黄・90% 赤）・コスト・経過時間・差分行数
  - `git status --porcelain=v2 --branch` 1回で git 情報を取得し、`session_id` キーで5秒キャッシュ・2秒タイムアウト
  - `COLUMNS` を見て狭い端末では末尾セグメントから省略
- `agents/claude/CLAUDE.md` を追加（日本語応答、nix 管理ファイルを直接編集しない、設定の正の所在）
- README を更新（配置表・コピーコマンドに設定3ファイルを追加、`settings.json` 登録スニペットは登録済みのため削除）

## 補足

- `home.file` によるシンボリックリンク化はしない。`~/.claude` が読み取り専用になると Claude Code 自身（`/config`、権限ダイアログの「常に許可」、プラグイン導入）が設定を書き換えられなくなるため。理由は README にも記載した
- `statusline.py` は shebang を `/usr/bin/python3` に固定し `jq` も使わない。ステータスラインを起動するシェルで nix profile / mise shim の PATH が揃う保証がないため
- フック登録のパスは `~/.claude/hooks/branch-guard.sh`。チルダ展開が効くことを実セッションで確認済み（ユーザー名のハードコードを回避）

## 検証

- `claude doctor` — issue なし
- headless セッション起動 — 権限ルールの起動時警告ゼロ（不正なパスルールや未アンカーの allow glob は警告が出る仕様）
- `statusline.py` — `PATH=/usr/bin:/bin` の最小環境で正常出力、幅 44/55/70 での省略動作、git 外・データ空・不正 JSON でのフォールバックを確認
- `branch-guard.sh` — feature ブランチでの commit は許可（exit 0）、`git push origin main` はブロック（exit 2）を確認

## 関連情報

- #19（`agents/` ディレクトリの導入）
- #20（commands / skills / hooks の追加）

https://claude.ai/code/session_01Ga3EBC2ceHzZRWLXNnZxhc
