### PR TITLE
feat(agents): wire herdr's Claude Code integration

### DIFF
--- a/agents/claude/hooks/herdr-agent-state.sh
+++ b/agents/claude/hooks/herdr-agent-state.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# installed by herdr
+# managed by herdr; reinstalling or updating the integration overwrites this file.
+# add custom hooks beside this file instead of editing it.
+# HERDR_INTEGRATION_ID=claude
+# HERDR_INTEGRATION_VERSION=7
+
+set -eu
+
+action="${1:-}"
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-claude-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+case "$action" in
+  session) ;;
+  *) exit 0 ;;
+esac
+
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+HERDR_ACTION="$action" HERDR_HOOK_INPUT_FILE="$hook_input_file" python3 - <<'PY'
+import json
+import os
+import random
+import socket
+import time
+
+source = "herdr:claude"
+action = os.environ.get("HERDR_ACTION", "")
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+hook_event_name = str(hook_input.get("hook_event_name") or "")
+is_subagent = bool(hook_input.get("agent_id"))
+if is_subagent:
+    raise SystemExit(0)
+if hook_event_name == "SubagentStop":
+    # SubagentStop is a completion event. Older Herdr integrations mapped it
+    # to durable working, but Claude recap/away-summary can emit it after the
+    # main turn has already stopped. Never let it revive an idle pane.
+    raise SystemExit(0)
+request_id = f"{source}:{int(time.time() * 1000)}:{random.randrange(1_000_000):06d}"
+report_seq = time.time_ns()
+session_id = hook_input.get("session_id")
+agent_session_id = session_id if isinstance(session_id, str) and session_id else None
+transcript_path = hook_input.get("transcript_path")
+agent_session_path = transcript_path if isinstance(transcript_path, str) and transcript_path else None
+session_start_source = hook_input.get("source") if hook_event_name == "SessionStart" else None
+if not isinstance(session_start_source, str) or not session_start_source:
+    session_start_source = None
+if agent_session_id:
+    params = {
+        "pane_id": pane_id,
+        "source": source,
+        "agent": "claude",
+        "seq": report_seq,
+        "agent_session_id": agent_session_id,
+    }
+    if agent_session_path:
+        params["agent_session_path"] = agent_session_path
+    if session_start_source:
+        params["session_start_source"] = session_start_source
+    request = {
+        "id": request_id,
+        "method": "pane.report_agent_session",
+        "params": params,
+    }
+else:
+    raise SystemExit(0)
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY

--- a/agents/claude/settings.json
+++ b/agents/claude/settings.json
@@ -143,6 +143,19 @@
   },
 
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '/Users/wadakatu/.claude/hooks/herdr-agent-state.sh' session",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
# 概要

**herdr**（ターミナル用のエージェント多重化ツール）の Claude Code 連携フックをリポジトリ管理下に置き、新しい Mac でも herdr がサーバ再起動後に Claude Code のネイティブセッションへ復帰できる状態を再現できるようにする。herdr 本体と `~/.config/herdr` の設定は README 179 行目の方針どおりローカル管理のままとし、宣言化するのは Claude Code 側の設定だけに絞る。

## 変更内容

- `agents/claude/hooks/herdr-agent-state.sh` を追加（herdr 0.7.5 が生成、integration version 7）
  - `HERDR_ENV=1` かつ `HERDR_SOCKET_PATH` / `HERDR_PANE_ID` が揃うペイン内でのみ動作し、それ以外では即 `exit 0`
  - ローカルの Unix socket に `pane.report_agent_session` で session_id と transcript のパスを通知するだけ。外部通信はしない
  - サブエージェントと `SubagentStop` は明示的に無視する実装になっている
- `agents/claude/settings.json` に `SessionStart` フックを登録

## 補足

- **フックのパスはユーザー名をハードコードしている。** #21 で「チルダ展開でユーザー名のハードコードを回避」という方針を採ったが、ここでは意図的に破っている。`herdr integration install claude` は登録済みコマンド文字列と**完全一致**しない限り重複エントリを追加する実装で、`$HOME` 表記に書き換えて再実行したところ `SessionStart` が 2 件に増えることを実測で確認した。絶対パスを維持すれば再実行しても 1 件のままになる。herdr のバージョンアップのたびに同じコマンドが走る前提なので、冪等性を優先した
- **`herdr integration install claude` は `settings.json` を再シリアライズする。** キーをアルファベット順にソートし、セクション区切りの空行を落とし、末尾改行も消す。本 PR では既存の整形を手で復元したうえで `SessionStart` を挿入し、`jq -S` で内容が一致することを確認した。今後 herdr の連携を入れ直したときは同じ復元作業が要る
- この連携が提供するのは**セッション同一性の復帰のみ**で、サイドバーの状態判定は従来どおり画面解析ベースのまま。公式ドキュメントにも「フックはライフサイクル全体をカバーしない」と明記されている

## 検証

- `herdr integration status` → `claude: current (v7)`
- `herdr integration install claude` を再実行しても `SessionStart` が 1 件のままであることを確認（冪等）
- 整形復元後の `settings.json` が herdr の生成結果と意味的に等価であることを `jq -S` の差分ゼロで確認。`jq -e .` で JSON としても妥当
- CI: `check` / `build-darwin` ともに pass

## 変更履歴

当初は hunk（エージェントが書いた差分をレビューするターミナル diff ビューア）の `homebrew.brews` への追加を含んでいたが、運用してみて不要と判断したため取り下げた。本 PR は herdr の Claude Code 連携のみを対象とする。
