### PR TITLE
feat(agents): start Claude Code in auto permission mode

### DIFF
--- a/agents/claude/settings.json
+++ b/agents/claude/settings.json
@@ -30,6 +30,8 @@
   "askUserQuestionTimeout": "10m",
 
   "permissions": {
+    "defaultMode": "auto",
+
     "deny": [
       "Read(//**/.env)",
       "Read(//**/.env.local)",

--- a/agents/claude/settings.json
+++ b/agents/claude/settings.json
@@ -81,6 +81,7 @@
       "Bash(git worktree list *)",
       "Bash(git shortlog *)",
       "Bash(git describe *)",
+      "Bash(git push *)",
 
       "Bash(gh pr view *)",
       "Bash(gh pr list *)",


### PR DESCRIPTION
# 概要

Claude Code のセッションを毎回 manual モードで始めるのをやめ、auto mode を既定にする。あわせて `git push` を許可ルールに追加する。

## 変更内容

`agents/claude/settings.json`

- `permissions.defaultMode: "auto"` を追加。分類器モデルが実行前に各アクションを審査し、要求を超えるもの・信頼していないインフラを対象にするもの・読み込んだ敵対的コンテンツに駆動されたものをブロックする
  - **user settings に置く必要がある**。v2.1.142 以降、プロジェクト設定とローカル設定の `auto` は無視される（リポジトリが自分自身に auto mode を付与できないようにするため）。エラーも出ずに `default` で起動するので気づきにくい
  - 既存の `ask` ルール（`darwin-rebuild` / `home-manager` / `nix run nix-darwin` / `nix-collect-garbage` / `brew` / `git config --global`）は auto mode でも必ずプロンプトが出る。`deny` の21件も従来どおり
  - 分類器が3回連続または合計20回ブロックすると auto mode は一時停止して通常のプロンプトに戻る（閾値は変更不可）
- `Bash(git push *)` を allow に追加。プレフィックスルールなので force push とリモートブランチ削除も含む
  - 分類器の判定順は「allow / ask / deny ルールに一致するアクションは即座に解決」が第1段なので、既定でブロックされる force push もこのルールで通る
  - auto mode 移行時に落とされるのは `Bash(*)` のような包括ルール・ワイルドカードなインタプリタ・パッケージマネージャの run 系・`Agent` ルールのみ。この粒度のルールは維持される
  - `branch-guard.sh`（PreToolUse フック）は許可ルールより前に動くため、main/master/dev 上からの push と、それらを明示的に対象にする push は引き続きブロックされる

## 関連情報

- [Choose a permission mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) — auto mode の利用条件、既定のブロック / 許可一覧、分類器の判定順、フォールバック
- [Settings](https://code.claude.com/docs/en/settings) — `permissions.defaultMode` の有効値と置き場所の制約
- [Configure auto mode](https://code.claude.com/docs/en/auto-mode-config) — 誤検知が多い場合の `autoMode.environment` による信頼インフラの登録
- 利用条件はすべて充足: 全プラン対応 / Anthropic API では Opus 4.6 以降が必要（Opus 5 を使用）/ Anthropic API は既定で利用可

### 補足

公式の注意書き: 「Auto mode reduces permission prompts but does not guarantee safety. Use it for tasks where you trust the general direction, not as a replacement for review on sensitive operations.」

会話中で述べた境界（「push しないで」等）も分類器はブロック信号として扱うが、これはトランスクリプトから毎回読み直すためコンテキスト圧縮で失われうる。確実に止めたいものは `deny` ルールにする。

`defaultMode` は起動時のモードを決めるキーのため、反映確認は次回セッション起動時に行う。auto mode の opt-in ダイアログが初回に一度だけ出る可能性がある（`skipAutoPermissionPrompt` が未設定のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x4Lo3aMgwaFjwx4rRhN3v
