### PR TITLE
feat(home): manage herdr config via out-of-store symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Nix由来のパッケージと設定は `flake.lock` で固定する。Homebrew 
 | mise とグローバルランタイム | Home Manager `programs.mise` |
 | Neovim と設定 | Home Manager + `home/config/nvim` |
 | Ghostty と設定 | Homebrew cask + Home Manager |
+| herdr の設定 | `home/config/herdr/config.toml` を Home Manager が out-of-store symlink（本体は Nix 管理外） |
 | CLI パッケージ | nixpkgs `home.packages` |
 | GUI アプリ | nix-darwin `homebrew.casks` |
 | Dock / Finder / キーボード / スクリーンショット | nix-darwin `system.defaults` |
@@ -43,12 +44,14 @@ Nix由来のパッケージと設定は `flake.lock` で固定する。Homebrew 
 │   ├── default.nix
 │   ├── git.nix
 │   ├── ghostty.nix
+│   ├── herdr.nix
 │   ├── mise.nix
 │   ├── neovim.nix
 │   ├── packages.nix
 │   ├── zsh.nix
 │   └── config/
 │       ├── ghostty/config
+│       ├── herdr/config.toml
 │       ├── nvim/
 │       └── starship.toml
 ├── modules/homebrew.nix
@@ -177,6 +180,39 @@ cp -R agents/codex/skills/* ~/.codex/skills/
 
 home 側で直接編集した場合は同じ対応でリポジトリへ取り込み直す。ここにないスキル
 （herdr、hatch-pet など外部配布物や実験中のもの）はローカル管理のままとする。
+
+## herdr の設定
+
+herdr（AI コーディングエージェント用のターミナルワークスペースマネージャ）本体は
+`herdr update` が自前で `~/.local/bin` を更新するため Nix 管理外。設定ファイルだけを
+`home/config/herdr/config.toml` に置き、`home/herdr.nix` から Home Manager の
+`mkOutOfStoreSymlink` で `~/.config/herdr/config.toml` へリンクする。
+
+Ghostty のように `.source = ./config/...` としないのは、herdr が config.toml を
+自分で書き換えるため。`/nix/store` への読み取り専用リンクにすると、オンボーディング
+完了時の `onboarding = false` 書き込みや `herdr config reset-keys` が失敗する
+（`~/.claude` を symlink にしない理由と同じ）。
+
+`mkOutOfStoreSymlink` は `/nix/store` を経由せず指定した絶対パスへ直接リンクを張る
+ヘルパー。実体はリポジトリ側の1ファイルだけになるので、
+
+- herdr 自身の書き換えが通り、その差分がそのまま `git status` に出る
+- 設定をいじるたびに `darwin-rebuild switch` する必要がない（`herdr server reload-config`
+  だけで反映される）
+
+flake では相対パスを渡すと flake source の store コピーを指してしまうため、
+`config.home.homeDirectory` を使った絶対パスの文字列を渡している
+（[home-manager#2085](https://github.com/nix-community/home-manager/issues/2085)）。
+このため、このリポジトリのクローン先は `~/www/dotfiles` である前提。
+
+なお、herdr が書き換え時に「一時ファイル + rename」方式を使う場合は
+`~/.config/herdr/config.toml` の symlink 自体が実ファイルに置き換わり、リポジトリから
+切り離される。設定を変えたのに `git status` に出ないときはこれを疑い、
+`ls -l ~/.config/herdr/config.toml` で symlink のままか確認する。
+
+エージェント状態検知のフック `agents/claude/hooks/herdr-agent-state.sh` は
+`herdr integration install claude` が生成するもので、こちらは他の Claude Code 設定と
+同じく手動コピー運用。
 
 ## シークレットと移行対象外データ
 

--- a/home/config/herdr/config.toml
+++ b/home/config/herdr/config.toml
@@ -1,0 +1,107 @@
+# herdr configuration (herdr 0.7.5)
+# Reference: https://herdr.dev/docs/configuration/
+# Keyboard:  https://herdr.dev/docs/keyboard/
+#
+# Reload without restarting panes:  herdr server reload-config  (prefix+shift+R)
+# Print upstream defaults:          herdr --default-config
+
+# config.toml が無いと毎回オンボーディングが出る。選択済みなので false。
+onboarding = false
+
+[theme]
+# Ghostty 側が Tokyo Night (~/.config/ghostty/config) なので揃える。
+name = "tokyo-night"
+
+[terminal]
+# "auto" = macOS では login shell で起動する。
+# nix-darwin は /etc/zshenv のガード (__NIX_DARWIN_SET_ENVIRONMENT_DONE) で
+# PATH を組むため、non_login にすると PATH が欠ける事故が起きやすい。auto 固定。
+shell_mode = "auto"
+# 新規ペイン/タブは元のペインの cwd を引き継ぐ。
+new_cwd = "follow"
+
+[update]
+channel = "stable"
+version_check = true
+
+[keys]
+# tmux / zellij は未インストールなので既定の ctrl+b をそのまま使う。
+prefix = "ctrl+b"
+
+# 公式が「全プラットフォームで最も安全」と明言している ctrl+alt 系の直接チョードを
+# prefix 版と併記する（配列構文で両方が同時に有効）。
+# https://herdr.dev/docs/keyboard/
+focus_pane_left    = ["prefix+h", "ctrl+alt+h"]
+focus_pane_down    = ["prefix+j", "ctrl+alt+j"]
+focus_pane_up      = ["prefix+k", "ctrl+alt+k"]
+focus_pane_right   = ["prefix+l", "ctrl+alt+l"]
+previous_tab       = ["prefix+p", "ctrl+alt+["]
+next_tab           = ["prefix+n", "ctrl+alt+]"]
+new_tab            = ["prefix+c", "ctrl+alt+c"]
+split_vertical     = ["prefix+v", "ctrl+alt+d"]
+split_horizontal   = ["prefix+minus", "ctrl+alt+shift+d"]
+zoom               = ["prefix+z", "ctrl+alt+z"]
+
+# 既定では未割り当ての indexed バインド。エージェント多重化ではここが効く。
+switch_tab       = "prefix+1..9"
+switch_workspace = "prefix+shift+1..9"
+focus_agent      = "prefix+alt+1..9"   # サイドバーの N 番目のエージェントへ直行
+
+# 直前のペインへ往復。既定では未割り当て（prefix+tab は cycle_pane_next が使用中）。
+last_pane = "prefix+backtick"
+
+[ui]
+# 分割時にどのペインがどのエージェントか枠に出す（既定 false）。
+show_agent_labels_on_pane_borders = true
+
+# タブが1枚のときはタブ行を隠して縦を稼ぐ（既定 false）。
+hide_tab_bar_when_single_tab = true
+
+# "spaces" = ワークスペース順 / "priority" = 要対応の待ち行列順。
+# 複数エージェントを回すなら priority のほうが「今どれが止まっているか」に直結する。
+agent_panel_sort = "priority"
+
+# サイドバーのエージェント行。Claude Code はターミナルタイトルに作業内容が出るので表示する。
+[ui.sidebar.agents]
+rows = [["state_icon", "workspace", "tab"], ["agent", "state_text"]]
+
+[ui.sidebar.agents.rows_by_agent]
+claude = [
+  ["state_icon", "workspace", "tab"],
+  ["terminal_title_stripped"],
+  ["agent", "state_text"],
+]
+
+# Git ブランチと変更状況をスペース行に出す。
+[ui.sidebar.spaces]
+rows = [["state_icon", "workspace"], ["branch", "git_status"]]
+
+[ui.toast]
+# エージェントが done / blocked になったことに気づけないと多重化の意味が薄いので、
+# OS の通知センターに出す。Ghostty 側に任せたい場合は "terminal"、
+# herdr の画面内トーストだけにしたい場合は "herdr"。
+delivery = "system"
+delay_seconds = 1
+
+[session]
+# サーバ再起動後にエージェントのネイティブセッションへ復帰する。
+# 効かせるには `herdr integration install claude` が必要。
+resume_agents_on_restore = true
+
+[experimental]
+# --- 日本語 IME まわり（macOS 限定・このマシンで効く設定） ---
+# prefix モード中だけ ASCII 入力ソースへ一時切り替え。
+# 日本語入力中に prefix+... が効かない問題への対策。
+switch_ascii_input_source_in_prefix = true
+
+# Claude Code / Codex のような自前でカーソルを描く TUI に対して、
+# 外側ターミナルへカーソル位置を露出し、変換候補ウィンドウを追従させる。
+reveal_hidden_cursor_for_cjk_ime = true
+cjk_ime_agents = ["claude", "codex"]
+
+# サーバ完全再起動をまたいでペインの画面履歴を保持する（既定 false）。
+pane_history = true
+
+# Ghostty は Kitty graphics 対応なので有効化できるが、描画不具合の報告余地が
+# あるため既定 false のまま。画像を出したくなったら true に。
+# kitty_graphics = false

--- a/home/default.nix
+++ b/home/default.nix
@@ -7,6 +7,7 @@
     ./mise.nix
     ./neovim.nix
     ./ghostty.nix
+    ./herdr.nix
     ./packages.nix
   ];
 

--- a/home/herdr.nix
+++ b/home/herdr.nix
@@ -1,0 +1,21 @@
+{ config, ... }: {
+  # herdr 本体は herdr 自身の updater (`herdr update`) が ~/.local/bin へ入れるので
+  # Nix では管理せず、設定ファイルだけをリポジトリ側に置く。
+
+  # ghostty のように `.source = ./config/...` で書くと /nix/store への読み取り専用
+  # symlink になるが、herdr は config.toml を自分で書き換えるため使えない
+  #   - オンボーディング完了時に `onboarding = false` を書き込む
+  #   - `herdr config reset-keys` が config.toml をバックアップして書き換える
+  # ~/.claude を symlink にしていないのと同じ理由 (README「エージェントスキルとコマンド」)。
+  #
+  # mkOutOfStoreSymlink: home-manager が /nix/store を経由せず、指定した絶対パスへ
+  # 直接 symlink を張るためのヘルパー。実体はリポジトリ側の1ファイルだけになり、
+  #   - 書き込み可能なので herdr 自身の書き換えが通る
+  #   - その書き換えがそのまま `git status` に出る
+  #   - 設定をいじるたびの darwin-rebuild が不要
+  # という状態になる。flake では相対パス (./config/...) を渡すと flake source の
+  # store コピーを指してしまうため、絶対パスの文字列を渡す (home-manager#2085)。
+  xdg.configFile."herdr/config.toml".source =
+    config.lib.file.mkOutOfStoreSymlink
+      "${config.home.homeDirectory}/www/dotfiles/home/config/herdr/config.toml";
+}


### PR DESCRIPTION
# 概要

herdr の設定ファイル `~/.config/herdr/config.toml` がどこにもバックアップされていなかったので、リポジトリ管理下に置く。herdr 自身が config.toml を書き換えるため、ghostty と同じ `/nix/store` への読み取り専用リンクではなく Home Manager の `mkOutOfStoreSymlink` を使う。

## 変更内容

`home/config/herdr/config.toml`（新規）

- 現行 `~/.config/herdr/config.toml` をそのままコピー。内容の変更なし

`home/herdr.nix`（新規） / `home/default.nix`

- `xdg.configFile."herdr/config.toml".source` に `config.lib.file.mkOutOfStoreSymlink` を使い、`~/.config/herdr/config.toml` → `~/www/dotfiles/home/config/herdr/config.toml` のリンクを張る
- **ghostty 方式（`.source = ./config/...`）にしない理由**: herdr は config.toml を自分で書き換えるため、`/nix/store` への読み取り専用リンクにすると失敗する
  - オンボーディング完了時に `onboarding = false` を書き込む
  - `herdr config reset-keys` が config.toml をバックアップして書き換える（`.bak-keybind-v2-*`）
  - バイナリ内に `config.write` / `changes_ui` のログイベントがあり、設定 UI からの書き込み経路も存在する
  - `~/.claude` を symlink にしていないのと同じ判断（README「エージェントスキルとコマンド」）
- flake では相対パスを渡すと flake source の store コピーを指してしまうため、`config.home.homeDirectory` から絶対パスを組み立てている。クローン先が `~/www/dotfiles` である前提が入る
- herdr 本体は `herdr update` が `~/.local/bin` を自前で更新するので Nix 管理外のまま

`README.md`

- 管理範囲テーブルと構成ツリーに追記
- 「herdr の設定」節を追加。方式の選択理由、rebuild なしで反映できること、symlink が実ファイルに置き換わって drift した場合の見分け方を記載

## 関連情報

- [home-manager `modules/files.nix`](https://github.com/nix-community/home-manager/blob/master/modules/files.nix) — `mkOutOfStoreSymlink` の定義（`pkgs.runCommandLocal name {} "ln -s <path> $out"`）
- [home-manager#2085](https://github.com/nix-community/home-manager/issues/2085) — flake で相対パスを渡すと store コピーを指す問題
- [herdr Configuration](https://herdr.dev/docs/configuration/) — オンボーディング時の `onboarding = false` 書き込み、`config reset-keys` のバックアップ挙動、`HERDR_CONFIG_PATH`

### 検証

```
$ nix eval ....xdg.configFile."herdr/config.toml".target
.config/herdr/config.toml

$ ls -la $(nix build --no-link --print-out-paths ....source)
/nix/store/yharr...-hm_config.toml -> /Users/wadakatu/www/dotfiles/home/config/herdr/config.toml
```

store 側が中身のコピーではなく絶対パスへの symlink になっていることを確認済み。`darwin-rebuild build` / `switch` は未実行。

### 適用時の注意

`backupFileExtension = "before-hm"` が効くため、既存の `~/.config/herdr/config.toml` は `config.toml.before-hm` へ退避されてからリンクに置き換わる。内容は同一なので確認後に削除してよい。

### 未検証

herdr が config.toml を書き換える際に「一時ファイル + rename」を使うかどうかは未確認。使う場合は `~/.config/herdr/config.toml` の symlink が実ファイルに置き換わり、リポジトリから切り離される。見分け方は README に記載した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaKP2x4EEPvWLbe24Rw9b7
