### PR TITLE
fix(agents): judge branch-guard by the repo the git command targets

### DIFF
--- a/agents/claude/hooks/branch-guard.sh
+++ b/agents/claude/hooks/branch-guard.sh
@@ -18,8 +18,10 @@ input=$(cat)
 # fallback over-matches (payload noise) but only costs a false block.
 if command -v jq >/dev/null 2>&1; then
   cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+  payload_cwd=$(printf '%s' "$input" | jq -r '.cwd // empty')
 else
   cmd=$input
+  payload_cwd=""
 fi
 
 case $cmd in
@@ -27,12 +29,33 @@ case $cmd in
   *) exit 0 ;;
 esac
 
+# Which repository does this command actually act on? CLAUDE_PROJECT_DIR is
+# only the session's root, and several projects keep sibling checkouts inside
+# it (dev-docker has app/, auth/, front/). Judging those by the outer repo's
+# HEAD blocks every commit in a sub-repo whenever the outer one sits on master.
+#
+# Order: an explicit `git -C <dir>` beats the session cwd, which beats the
+# project dir. A relative -C path is resolved against the cwd git itself would
+# use, so the three stay consistent.
 dir=${CLAUDE_PROJECT_DIR:-$PWD}
+[ -n "$payload_cwd" ] && [ -d "$payload_cwd" ] && dir=$payload_cwd
+
+target=$(printf '%s' "$cmd" \
+  | sed -n "s/.*git[[:space:]][[:space:]]*-C[[:space:]][[:space:]]*\([^[:space:]]*\).*/\1/p" \
+  | head -n1 \
+  | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/")
+if [ -n "$target" ]; then
+  case $target in
+    /*) dir=$target ;;
+    *)  dir="$dir/$target" ;;
+  esac
+fi
+
 branch=$(git -C "$dir" symbolic-ref --short -q HEAD) || exit 0
 
 for p in $PROTECTED; do
   if [ "$branch" = "$p" ]; then
-    echo "branch-guard: HEAD is on protected branch '$branch'." >&2
+    echo "branch-guard: HEAD is on protected branch '$branch' ($dir)." >&2
     echo "Create a feature branch first (e.g. git switch -c feature/<topic>) and retry." >&2
     exit 2
   fi

--- a/agents/claude/settings.json
+++ b/agents/claude/settings.json
@@ -2,11 +2,11 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
 
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": false,
     "superpowers@claude-plugins-official": true,
     "chrome-devtools-mcp@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": true,
-    "laravel-boost@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": false,
+    "laravel-boost@claude-plugins-official": false,
     "context7@claude-plugins-official": true
   },
 


### PR DESCRIPTION
## 概要

`branch-guard.sh` が「セッションのルートリポジトリ」の HEAD だけを見ていたため、サブリポジトリでの commit / push が誤ってブロックされていた。実際にコマンドが対象とするリポジトリで判定するようにする。

## 変更内容

`dev-docker` のようにチェックアウトを内側に並べる構成（`app/` `auth/` `front/`）だと、外側が `master` に居る限り内側のリポジトリでの commit が全部止まる。実際に studio-auth 側の作業中に踏んだ。

判定に使うディレクトリの優先順位を次のようにした。

1. コマンド中の明示的な `git -C <dir>`（相対パスは 2 の cwd 基準で解決するので、git 自身の解決と一致する）
2. PreToolUse ペイロードの `.cwd`
3. `CLAUDE_PROJECT_DIR`（従来の唯一の情報源）

ブロック時のメッセージにも判定対象のディレクトリを出すようにした。どのリポジトリを見て止めたのかが分からないと、誤検知かどうかの切り分けができないため。

既知の制限として、`cd <dir> && git push` のように `-C` を使わずディレクトリを移動する形は、ペイロードの `.cwd` が移動前のままなので従来どおり外側で判定される。安全側（余計にブロックする）に倒れるので今回は追わない。

`~/.claude/hooks/branch-guard.sh` にも同じ内容を反映済み。

## 検証

- 8 ケースの回帰スクリプトで確認（絶対パス `-C` / `-C` なしで master / 相対パス `-C` / cwd がサブリポジトリ / main を対象にした push / git 以外のコマンド / 存在しない cwd / `.cwd` 欠落）: 全て PASS
- 実地確認: 本ブランチの push 自体が `git -C <dotfiles> push` で通り、`cd && git push` 形式では従来どおりブロックされることを確認

## 関連情報

- 2 コミット目 `chore(agents): disable unused Claude Code plugins` は branch-guard とは独立した変更で、同ブランチに乗っていたものをそのまま含めている（`agents/claude/settings.json` の `enabledPlugins` を 3 つ false に）
